### PR TITLE
feat: add timezone-aware notification scheduling and weekly reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- `refreshLocalTimezone()` and `getConfiguredLocalTimezone()` on `FirebaseMessagingHandler.instance` for apps that reschedule reminders after app resume or timezone changes.
+- `configuredTimezone` metadata in `runDiagnostics()`.
+- `scheduleWeeklyNotification()` for recurring notifications on a specific weekday.
+
+### Fixed
+- Scheduled notifications now configure `tz.local` from the device timezone via `flutter_timezone` before calling `zonedSchedule`.
+
+---
+
 ## [1.0.4] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ clickStream?.listen((NotificationData? data) {
 
 ### **🎨 Advanced Features**
 - **⚡ Interactive Notification Actions** - Custom buttons with payload handling
-- **⏰ Notification Scheduling** - One-time and recurring notifications
+- **⏰ Notification Scheduling** - One-time and recurring notifications with device-timezone-aware scheduling
 - **🔢 Badge Management** - Cross-platform badge count management
 - **📦 Notification Grouping** - Android groups and iOS conversation threads
 - **🔊 Custom Sound Support** - Platform-specific sound customization
@@ -587,6 +587,12 @@ NotificationInboxView(
 ```
 
 ### **Notification Scheduling**
+
+Scheduled notifications use the device timezone. If your app reschedules reminders on resume, refresh the timezone first:
+
+```dart
+await FirebaseMessagingHandler.instance.refreshLocalTimezone();
+```
 
 ```dart
 // Schedule a one-time notification

--- a/doc/features/scheduling.md
+++ b/doc/features/scheduling.md
@@ -12,3 +12,60 @@ Scheduling is best paired with:
 - notification channels
 - quiet hours
 - analytics callbacks
+
+## Timezone handling
+
+Scheduled notifications use the device timezone. During initialization, the package loads timezone data, reads the device timezone with `flutter_timezone`, and sets `tz.local` before any `zonedSchedule` call.
+
+If your app supports reminders or alarms, call `refreshLocalTimezone()` when the app resumes before rescheduling reminders. This keeps reminder times aligned when users travel or manually change their system timezone.
+
+```dart
+final String? timezone =
+    await FirebaseMessagingHandler.instance.refreshLocalTimezone();
+
+final diagnostics =
+    await FirebaseMessagingHandler.instance.runDiagnostics();
+
+print(timezone);
+print(diagnostics.metadata['configuredTimezone']);
+```
+
+## One-time schedule
+
+```dart
+await FirebaseMessagingHandler.instance.scheduleNotification(
+  id: 1001,
+  title: 'Reminder',
+  body: 'Time to check in.',
+  scheduledDate: DateTime.now().add(const Duration(minutes: 10)),
+  payload: {'route': '/check-in'},
+);
+```
+
+## Recurring schedule
+
+```dart
+await FirebaseMessagingHandler.instance.scheduleRecurringNotification(
+  id: 2001,
+  title: 'Daily check-in',
+  body: 'Take a moment for yourself.',
+  repeatInterval: 'daily',
+  hour: 9,
+  minute: 0,
+  payload: {'route': '/check-in'},
+);
+```
+
+For selected weekdays such as Monday, Wednesday, and Friday, schedule one weekly notification per selected day with a stable ID for each day.
+
+```dart
+await FirebaseMessagingHandler.instance.scheduleWeeklyNotification(
+  id: 3001,
+  title: 'Monday check-in',
+  body: 'Take a moment for yourself.',
+  weekday: DateTime.monday,
+  hour: 9,
+  minute: 0,
+  payload: {'route': '/check-in'},
+);
+```

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_timezone/flutter_timezone_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_timezone_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterTimezonePlugin");
+  flutter_timezone_plugin_register_with_registrar(flutter_timezone_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_timezone
   url_launcher_linux
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import firebase_core
 import firebase_messaging
 import flutter_local_notifications
+import flutter_timezone
 import shared_preferences_foundation
 import url_launcher_macos
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -231,6 +239,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: transitive
+    description:
+      name: flutter_timezone
+      sha256: e8d63f50f2806a3a71a08697286a0369e1d8f0902961327810459871c0bb01c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterTimezonePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
+  flutter_timezone
   url_launcher_windows
 )
 

--- a/lib/firebase_messaging_handler.dart
+++ b/lib/firebase_messaging_handler.dart
@@ -17,6 +17,7 @@ export 'firebase_messaging_handler_linux.dart';
 export 'firebase_messaging_handler_windows.dart';
 
 @pragma('vm:entry-point')
+
 /// Default background dispatcher entry point that forwards work into the
 /// package-managed background handler pipeline.
 Future<void> firebaseMessagingHandlerBackgroundDispatcher(
@@ -448,7 +449,7 @@ class FirebaseMessagingHandler {
           interval = RepeatIntervalEnum.daily;
       }
 
-      await _notificationManager.scheduleRecurringNotification(
+      return await _notificationManager.scheduleRecurringNotification(
         id: id,
         title: title,
         body: body,
@@ -459,7 +460,38 @@ class FirebaseMessagingHandler {
         payload: payload,
         actions: actions,
       );
-      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Schedules a weekly notification on a specific weekday.
+  ///
+  /// [weekday] uses Dart's [DateTime] weekday constants:
+  /// `DateTime.monday` through `DateTime.sunday`.
+  Future<bool> scheduleWeeklyNotification({
+    required int id,
+    required String title,
+    required String body,
+    required int weekday,
+    required int hour,
+    required int minute,
+    String? channelId,
+    Map<String, dynamic>? payload,
+    List<NotificationAction>? actions,
+  }) async {
+    try {
+      return await _notificationManager.scheduleWeeklyNotification(
+        id: id,
+        title: title,
+        body: body,
+        weekday: weekday,
+        hour: hour,
+        minute: minute,
+        channelId: channelId,
+        payload: payload,
+        actions: actions,
+      );
     } catch (e) {
       return false;
     }
@@ -487,6 +519,19 @@ class FirebaseMessagingHandler {
   /// in the future. This is primarily supported on Android.
   Future<List<dynamic>?> getPendingNotifications() async {
     return await _notificationManager.getPendingNotifications();
+  }
+
+  /// Refreshes the device timezone used by scheduled local notifications.
+  ///
+  /// Call this on app resume before rescheduling reminders if users may travel
+  /// or change their system timezone while the app is backgrounded.
+  Future<String?> refreshLocalTimezone() async {
+    return await _notificationManager.refreshLocalTimezone();
+  }
+
+  /// Returns the timezone currently configured for scheduled notifications.
+  Future<String?> getConfiguredLocalTimezone() async {
+    return await _notificationManager.getConfiguredLocalTimezone();
   }
 
   /// Shows a grouped notification (Android notification groups)

--- a/lib/src/core/interfaces/notification_service_interface.dart
+++ b/lib/src/core/interfaces/notification_service_interface.dart
@@ -67,6 +67,12 @@ abstract class NotificationServiceInterface {
   /// Gets pending notifications
   Future<List<dynamic>> getPendingNotifications();
 
+  /// Refreshes the timezone used by scheduled notifications.
+  Future<String?> refreshLocalTimezone();
+
+  /// Returns the timezone currently configured for scheduling.
+  Future<String?> getConfiguredLocalTimezone();
+
   /// Creates a notification channel
   Future<void> createNotificationChannel(NotificationChannelData channel);
 

--- a/lib/src/core/managers/notification_manager.dart
+++ b/lib/src/core/managers/notification_manager.dart
@@ -37,8 +37,7 @@ class NotificationManager {
       FirebaseMessagingHandlerNotificationService.instance;
   final FmhAnalyticsService _analyticsService = FmhAnalyticsService.instance;
   final StorageService _storageService = StorageService.instance;
-  final NotificationInboxStorageInterface _inboxStorage =
-      InboxStorageService();
+  final NotificationInboxStorageInterface _inboxStorage = InboxStorageService();
 
   final InAppMessageManager _inAppMessageManager = InAppMessageManager.instance;
   final BadgeManager _badgeManager = BadgeManager.instance;
@@ -120,7 +119,8 @@ class NotificationManager {
       );
 
       // Handle FCM token
-      await _handleFCMToken(senderId, updateTokenCallback, webVapidKey: webVapidKey);
+      await _handleFCMToken(senderId, updateTokenCallback,
+          webVapidKey: webVapidKey);
 
       if (updateTokenCallback != null) {
         _listenForTokenRefresh(updateTokenCallback);
@@ -164,8 +164,8 @@ class NotificationManager {
           if (_pendingClickEvents.isEmpty) {
             return;
           }
-          for (final NotificationData? event in List<NotificationData?>.from(
-              _pendingClickEvents)) {
+          for (final NotificationData? event
+              in List<NotificationData?>.from(_pendingClickEvents)) {
             _clickStreamController?.add(event);
           }
           _pendingClickEvents.clear();
@@ -236,8 +236,7 @@ class NotificationManager {
 
   /// Processes a notification
   Future<void> processNotification(RemoteMessage message,
-      {bool isFromTerminated = false,
-      bool emitToClickStream = true}) async {
+      {bool isFromTerminated = false, bool emitToClickStream = true}) async {
     try {
       if (!_openedNotifications.contains(message.messageId.hashCode)) {
         _openedNotifications.add(message.messageId.hashCode);
@@ -388,6 +387,28 @@ class NotificationManager {
     } catch (error, stack) {
       _logMessage(
           '[NotificationManager] Get pending notifications error: $error');
+      _logMessage('[NotificationManager] Stack trace: $stack');
+      return null;
+    }
+  }
+
+  /// Refreshes the timezone used for local notification scheduling.
+  Future<String?> refreshLocalTimezone() async {
+    try {
+      return await _notificationService.refreshLocalTimezone();
+    } catch (error, stack) {
+      _logMessage('[NotificationManager] Refresh timezone error: $error');
+      _logMessage('[NotificationManager] Stack trace: $stack');
+      return null;
+    }
+  }
+
+  /// Returns the timezone currently configured for local scheduling.
+  Future<String?> getConfiguredLocalTimezone() async {
+    try {
+      return await _notificationService.getConfiguredLocalTimezone();
+    } catch (error, stack) {
+      _logMessage('[NotificationManager] Get timezone error: $error');
       _logMessage('[NotificationManager] Stack trace: $stack');
       return null;
     }
@@ -546,8 +567,7 @@ class NotificationManager {
     _dataOnlyMessageBridge = bridge;
   }
 
-  Future<void> setUnifiedMessageHandler(
-      UnifiedMessageHandler? handler) async {
+  Future<void> setUnifiedMessageHandler(UnifiedMessageHandler? handler) async {
     _unifiedMessageHandler = handler;
     if (handler != null) {
       await _replayQueuedBackgroundMessages();
@@ -607,12 +627,13 @@ class NotificationManager {
       _analyticsService.trackNotificationReceived(message);
       await _maybeBridgeDataOnlyMessage(message);
 
-      bool handled =
-          await _invokeUnifiedHandler(message, NotificationLifecycle.background);
+      bool handled = await _invokeUnifiedHandler(
+          message, NotificationLifecycle.background);
 
       if (_backgroundMessageCallback != null) {
         try {
-          final bool callbackHandled = await _backgroundMessageCallback!(message);
+          final bool callbackHandled =
+              await _backgroundMessageCallback!(message);
           handled = handled && callbackHandled;
         } catch (error, stack) {
           _logMessage(
@@ -650,6 +671,8 @@ class NotificationManager {
       final bool badgeSupported = await _notificationService.isBadgeSupported();
       final List<dynamic> pendingNotifications =
           await _notificationService.getPendingNotifications();
+      final String? configuredTimezone =
+          await _notificationService.getConfiguredLocalTimezone();
 
       final String webPermission =
           await _notificationService.getWebNotificationPermissionStatus();
@@ -671,9 +694,8 @@ class NotificationManager {
       }
 
       if (!fcmSupported) {
-        recommendations.add(
-            _fcmService.unsupportedPlatformReason ??
-                'Firebase Cloud Messaging is unavailable on this platform.');
+        recommendations.add(_fcmService.unsupportedPlatformReason ??
+            'Firebase Cloud Messaging is unavailable on this platform.');
         recommendations.add(
             'Use local notifications, scheduling, inbox, and in-app templates on desktop. For remote delivery, send through your own backend and handle desktop presentation locally.');
       }
@@ -693,8 +715,7 @@ class NotificationManager {
             'Browser notifications are currently "$webPermission". Trigger a permission prompt or guide the user to allow notifications.');
       }
 
-      if (isWeb &&
-          webRuntimeDiagnostics['notificationApiAvailable'] == false) {
+      if (isWeb && webRuntimeDiagnostics['notificationApiAvailable'] == false) {
         recommendations.add(
             'This browser does not expose the Notification API. Use a supported browser such as Chrome, Edge, or Safari with web notifications enabled.');
       }
@@ -744,6 +765,7 @@ class NotificationManager {
           'webPermission': webPermission,
           'webDiagnostics': webRuntimeDiagnostics,
           'storedTokenPresent': tokenAvailable,
+          'configuredTimezone': configuredTimezone,
           'deliveryPolicy': deliveryDiagnostics,
           'queuedBackgroundMessages': queuedBackgroundMessages,
           'dataBridgeEnabled': _dataOnlyMessageBridge != null,
@@ -977,8 +999,7 @@ class NotificationManager {
         await _maybeBridgeDataOnlyMessage(message);
       }
 
-      await _invokeUnifiedHandler(
-          message, NotificationLifecycle.foreground);
+      await _invokeUnifiedHandler(message, NotificationLifecycle.foreground);
 
       if (!_foregroundOptions.enabled) {
         return;
@@ -1224,8 +1245,7 @@ class NotificationManager {
     if (event == null) {
       return;
     }
-    if (_clickStreamController != null &&
-        _clickStreamController!.hasListener) {
+    if (_clickStreamController != null && _clickStreamController!.hasListener) {
       _clickStreamController!.add(event);
     } else {
       _pendingClickEvents.add(event);
@@ -1351,7 +1371,7 @@ class NotificationManager {
   }
 
   /// Schedules a recurring notification
-  Future<void> scheduleRecurringNotification({
+  Future<bool> scheduleRecurringNotification({
     required int id,
     required String title,
     required String body,
@@ -1392,10 +1412,61 @@ class NotificationManager {
         _logMessage(
             '[NotificationManager] Recurring notification scheduled: $id (${repeatInterval.name})');
       }
+      return scheduled;
     } catch (error, stack) {
       _logMessage(
           '[NotificationManager] Schedule recurring notification error: $error');
       _logMessage('[NotificationManager] Stack trace: $stack');
+      return false;
+    }
+  }
+
+  /// Schedules a weekly notification on a specific weekday.
+  Future<bool> scheduleWeeklyNotification({
+    required int id,
+    required String title,
+    required String body,
+    required int weekday,
+    required int hour,
+    required int minute,
+    String? channelId,
+    Map<String, dynamic>? payload,
+    List<NotificationAction>? actions,
+  }) async {
+    try {
+      final DateTime initial = _nextWeeklyDate(
+        weekday: weekday,
+        hour: hour,
+        minute: minute,
+      );
+
+      final bool scheduled =
+          await _notificationService.scheduleRecurringNotification(
+        id: id,
+        title: title,
+        body: body,
+        repeatInterval: RepeatIntervalEnum.weekly,
+        initialScheduleDate: initial,
+        channelId: channelId,
+        payload: payload,
+        actions: actions,
+      );
+
+      if (scheduled) {
+        _analyticsService.trackEvent('notification_scheduled_weekly', {
+          'notification_id': id,
+          'title': title,
+          'weekday': weekday,
+          'scheduled_start': initial.toIso8601String(),
+        });
+        _logMessage(
+            '[NotificationManager] Weekly notification scheduled: $id (weekday: $weekday)');
+      }
+      return scheduled;
+    } catch (error, stack) {
+      _logMessage('[NotificationManager] Schedule weekly error: $error');
+      _logMessage('[NotificationManager] Stack trace: $stack');
+      return false;
     }
   }
 
@@ -1530,10 +1601,10 @@ class NotificationManager {
 
       final String? title =
           message.notification?.title ?? data['title'] as String?;
-      final String? body = message.notification?.body ?? data['body'] as String?;
+      final String? body =
+          message.notification?.body ?? data['body'] as String?;
 
-      if ((title == null || title.isEmpty) &&
-          (body == null || body.isEmpty)) {
+      if ((title == null || title.isEmpty) && (body == null || body.isEmpty)) {
         return;
       }
 
@@ -1576,8 +1647,7 @@ class NotificationManager {
           if (action is! Map) {
             return null;
           }
-          final Map<String, dynamic> parsed =
-              Map<String, dynamic>.from(action);
+          final Map<String, dynamic> parsed = Map<String, dynamic>.from(action);
           final String? id = parsed['id']?.toString();
           final String? title = parsed['title']?.toString();
           if (id == null || title == null) {
@@ -1594,5 +1664,26 @@ class NotificationManager {
         })
         .whereType<NotificationAction>()
         .toList();
+  }
+
+  DateTime _nextWeeklyDate({
+    required int weekday,
+    required int hour,
+    required int minute,
+  }) {
+    final int normalizedWeekday = weekday.clamp(
+      DateTime.monday,
+      DateTime.sunday,
+    );
+    final DateTime now = DateTime.now();
+    var initial = DateTime(now.year, now.month, now.day, hour, minute);
+    final int daysUntilTarget =
+        (normalizedWeekday - initial.weekday + DateTime.daysPerWeek) %
+            DateTime.daysPerWeek;
+    initial = initial.add(Duration(days: daysUntilTarget));
+    if (initial.isBefore(now) || initial.isAtSameMomentAs(now)) {
+      initial = initial.add(const Duration(days: DateTime.daysPerWeek));
+    }
+    return initial;
   }
 }

--- a/lib/src/core/services/firebase_messaging_handler_notification_service.dart
+++ b/lib/src/core/services/firebase_messaging_handler_notification_service.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 import '../utils/web_interop.dart' as web_interop;
 import '../interfaces/notification_service_interface.dart';
@@ -21,6 +22,7 @@ class FirebaseMessagingHandlerNotificationService
   bool _isInitialized = false;
   final StorageService _storageService = StorageService.instance;
   int? _cachedBadgeCount;
+  String? _configuredTimezoneIdentifier;
 
   /// Singleton instance
   static FirebaseMessagingHandlerNotificationService get instance {
@@ -56,8 +58,7 @@ class FirebaseMessagingHandlerNotificationService
 
       _localNotifications = FlutterLocalNotificationsPlugin();
 
-      // Initialize timezone data for scheduled notifications
-      tz.initializeTimeZones();
+      await refreshLocalTimezone();
 
       final InitializationSettings initializationSettings =
           InitializationSettings(
@@ -454,6 +455,16 @@ class FirebaseMessagingHandlerNotificationService
   }
 
   @override
+  Future<String?> refreshLocalTimezone() async {
+    return await _configureLocalTimeZone();
+  }
+
+  @override
+  Future<String?> getConfiguredLocalTimezone() async {
+    return _configuredTimezoneIdentifier;
+  }
+
+  @override
   Future<void> createNotificationChannel(
       NotificationChannelData channel) async {
     try {
@@ -550,7 +561,8 @@ class FirebaseMessagingHandlerNotificationService
     try {
       return web_interop.getWebRuntimeDiagnostics();
     } catch (error, stack) {
-      _logMessage('[NotificationService] Web runtime diagnostics error: $error');
+      _logMessage(
+          '[NotificationService] Web runtime diagnostics error: $error');
       _logMessage('[NotificationService] Stack trace: $stack');
       return <String, dynamic>{
         'supported': false,
@@ -819,6 +831,37 @@ class FirebaseMessagingHandlerNotificationService
           '[NotificationService] Configure iOS categories error: $error');
       _logMessage('[NotificationService] Stack trace: $stack');
     }
+  }
+
+  Future<String?> _configureLocalTimeZone() async {
+    if (isWeb) {
+      _configuredTimezoneIdentifier = null;
+      return null;
+    }
+
+    tz.initializeTimeZones();
+
+    if (isLinux || isWindows) {
+      _configuredTimezoneIdentifier = null;
+      return null;
+    }
+
+    try {
+      final TimezoneInfo timeZoneInfo =
+          await FlutterTimezone.getLocalTimezone();
+      final String identifier = timeZoneInfo.identifier.trim();
+      if (identifier.isNotEmpty) {
+        tz.setLocalLocation(tz.getLocation(identifier));
+        _configuredTimezoneIdentifier = identifier;
+        return identifier;
+      }
+    } catch (error, stack) {
+      _logMessage('[NotificationService] Configure timezone error: $error');
+      _logMessage('[NotificationService] Stack trace: $stack');
+    }
+
+    _configuredTimezoneIdentifier = null;
+    return null;
   }
 
   Future<void> _onNotificationResponse(NotificationResponse response) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 
   # Timezone handling for scheduled notifications
   timezone: ">=0.10.1 <1.0.0"
+  flutter_timezone: ">=5.0.0 <6.0.0"
 
   # HTML widget support for rich content
   flutter_widget_from_html_core: ">=0.17.0 <1.0.0"


### PR DESCRIPTION
## Summary

This PR strengthens local notification scheduling by making it device-timezone-aware and adding weekly reminder support.

It configures scheduled notifications using the user’s device timezone, adds APIs to refresh and inspect the active scheduling timezone, introduces weekday-based weekly scheduling, and exposes timezone details in diagnostics.

## Changes

- `flutter_timezone` added as a dependency to read the device timezone.
- Local notification initialization now calls timezone setup before scheduling notifications.
- Timezone setup now:
  - initializes timezone data
  - reads the device timezone
  - sets `tz.local`
  - stores the configured timezone identifier
- New public APIs added:
  - `refreshLocalTimezone()`
  - `getConfiguredLocalTimezone()`
  - `scheduleWeeklyNotification(...)`
- `scheduleRecurringNotification(...)` now returns the actual scheduling result instead of assuming success.
- Weekly scheduling now calculates the next valid occurrence for the requested weekday/time.
- `runDiagnostics()` now includes `configuredTimezone`.
- README, scheduling docs, changelog, and example generated files were updated.

## What To Test

1. Schedule a one-time notification and confirm it fires at the expected local time.
2. Schedule a daily recurring notification and confirm it returns `true` when scheduled.
3. Schedule a weekly notification for a specific weekday/time and confirm it targets the next valid occurrence.
4. Call `refreshLocalTimezone()` and verify the configured timezone is reflected in diagnostics.
5. Verify existing notification flows still work: immediate, recurring, cancel scheduled, and pending notifications.